### PR TITLE
Refactor getting_started messages into toolchain

### DIFF
--- a/.bluemix/locales_getting_started.yml
+++ b/.bluemix/locales_getting_started.yml
@@ -1,0 +1,29 @@
+---
+root:
+  $ref: ./nls/messages_getting_started.yml
+de:
+  $ref: ./nls/messages_getting_started_de.yml
+en-AA:
+  $ref: ./nls/messages_getting_started_en_AA.yml
+en-RR:
+  $ref: ./nls/messages_getting_started_en_RR.yml
+en-ZZ:
+  $ref: ./nls/messages_getting_started_en_ZZ.yml
+es:
+  $ref: ./nls/messages_getting_started_es.yml
+fr:
+  $ref: ./nls/messages_getting_started_fr.yml
+it:
+  $ref: ./nls/messages_getting_started_it.yml
+ja:
+  $ref: ./nls/messages_getting_started_ja.yml
+ko:
+  $ref: ./nls/messages_getting_started_ko.yml
+pt-BR:
+  $ref: ./nls/messages_getting_started_pt_BR.yml
+zh:
+  $ref: ./nls/messages_getting_started_zh.yml
+zh-HK:
+  $ref: ./nls/messages_getting_started_zh_HK.yml
+zh-TW:
+  $ref: ./nls/messages_getting_started_zh_TW.yml

--- a/.bluemix/nls/messages.yml
+++ b/.bluemix/nls/messages.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Build your own toolchain"
 template.description: "This toolchain has no preconfigured tools. If you are already familiar with toolchains, you can set up your own toolchain.\n\nTo get started, click **Create**."
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom?task=2) for this toolchain."

--- a/.bluemix/nls/messages_de.yml
+++ b/.bluemix/nls/messages_de.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Eigene Toolchain erstellen"
 template.description: "Diese Toolchain weist keine vorkonfigurierten Tools auf. Wenn Sie mit Toolchains bereits vertraut sind, können Sie Ihre eigene Toolchain einrichten.\n\nKlicken Sie auf **Erstellen**, um zu beginnen."
-template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Sie können jetzt Toolintegrationen hinzufügen. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) für diese Toolchain. "

--- a/.bluemix/nls/messages_en_AA.yml
+++ b/.bluemix/nls/messages_en_AA.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "1:Build your own toolchain"
 template.description: "2:This toolchain has no preconfigured tools. If you are already familiar with toolchains, you can set up your own toolchain.\n\nTo get started, click **Create**."
-template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain."

--- a/.bluemix/nls/messages_en_RR.yml
+++ b/.bluemix/nls/messages_en_RR.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Build your own toolchain~otc-ui711"
 template.description: "This toolchain has no preconfigured tools. If you are already familiar with toolchains, you can set up your own toolchain.\n\nTo get started, click **Create**.~otc-ui712"
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain.~otc-ui713"

--- a/.bluemix/nls/messages_en_ZZ.yml
+++ b/.bluemix/nls/messages_en_ZZ.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "[G'Ｂｕｉｌｄ ｙｏｕr own toolchainฏูİı｜]"
 template.description: "[G'Ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｈａｓ ｎｏ ｐｒｅｃｏｎｆｉｇｕｒｅｄ ｔｏｏｌｓ. Ｉｆ you are already familiar with toolchains, you can set up your own toolchain.\n\nTo get started, click **Create**.ฏูİı｜]"
-template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｙｏｕ ｃａｎ ｎｏｗ ａｄｄ ｔｏｏｌ ｉｎｔｅｇｒａｔｉｏｎs. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain.ฏูİı｜]"

--- a/.bluemix/nls/messages_es.yml
+++ b/.bluemix/nls/messages_es.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Cree su propia cadena de herramientas"
 template.description: "Esta cadena de herramientas no tiene herramientas preconfiguradas. Si ya está familiarizado con cadenas de herramientas, puede configurar su propia cadena de herramientas.\n\nPara comenzar, pulse **Crear**."
-template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Ahora puede añadir integraciones de herramientas. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) para esta cadena de aprendizaje. "

--- a/.bluemix/nls/messages_fr.yml
+++ b/.bluemix/nls/messages_fr.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Construisez votre propre chaîne d'outils"
 template.description: "Cette chaîne d'outils ne comporte aucun outil préconfiguré. Si vous connaissez déjà les chaînes d'outils, vous pouvez configurer votre propre chaîne d'outils.\n\nPour commencer, cliquez sur **Créer**."
-template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** vous pouvez maintenant ajouter des intégrations d'outils. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) relatif à cette chaîne d'outils. "

--- a/.bluemix/nls/messages_getting_started.yml
+++ b/.bluemix/nls/messages_getting_started.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom?task=2) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_de.yml
+++ b/.bluemix/nls/messages_getting_started_de.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Sie können jetzt Toolintegrationen hinzufügen. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) für diese Toolchain. "

--- a/.bluemix/nls/messages_getting_started_en_AA.yml
+++ b/.bluemix/nls/messages_getting_started_en_AA.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_en_RR.yml
+++ b/.bluemix/nls/messages_getting_started_en_RR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** You can now add tool integrations. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain.~otc-ui713"

--- a/.bluemix/nls/messages_getting_started_en_ZZ.yml
+++ b/.bluemix/nls/messages_getting_started_en_ZZ.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｙｏｕ ｃａｎ ｎｏｗ ａｄｄ ｔｏｏｌ ｉｎｔｅｇｒａｔｉｏｎs. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) for this toolchain.ฏูİı｜]"

--- a/.bluemix/nls/messages_getting_started_es.yml
+++ b/.bluemix/nls/messages_getting_started_es.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Ahora puede añadir integraciones de herramientas. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) para esta cadena de aprendizaje. "

--- a/.bluemix/nls/messages_getting_started_fr.yml
+++ b/.bluemix/nls/messages_getting_started_fr.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** vous pouvez maintenant ajouter des intégrations d'outils. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) relatif à cette chaîne d'outils. "

--- a/.bluemix/nls/messages_getting_started_it.yml
+++ b/.bluemix/nls/messages_getting_started_it.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:**Ora è possibile aggiungere le integrazioni di strumenti.Per le istruzioni passo dopo passo, consultare [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) per questa toolchain."

--- a/.bluemix/nls/messages_getting_started_ja.yml
+++ b/.bluemix/nls/messages_getting_started_ja.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** 現在、ツール統合を追加できます。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)を参照してください。"

--- a/.bluemix/nls/messages_getting_started_ko.yml
+++ b/.bluemix/nls/messages_getting_started_ko.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** 이제 도구 통합을 추가할 수 있습니다. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)을 참조하십시오."

--- a/.bluemix/nls/messages_getting_started_pt_BR.yml
+++ b/.bluemix/nls/messages_getting_started_pt_BR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Você agora pode incluir integrações de ferramenta. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) para esta cadeia de ferramentas."

--- a/.bluemix/nls/messages_getting_started_zh.yml
+++ b/.bluemix/nls/messages_getting_started_zh.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 现在您可以添加工具集成。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/nls/messages_getting_started_zh_HK.yml
+++ b/.bluemix/nls/messages_getting_started_zh_HK.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 您現在可以新增工具整合。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/nls/messages_getting_started_zh_TW.yml
+++ b/.bluemix/nls/messages_getting_started_zh_TW.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 您現在可以新增工具整合。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/nls/messages_it.yml
+++ b/.bluemix/nls/messages_it.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Crea la tua toolchain"
 template.description: "Questa toolchain non contiene alcuno strumento preconfigurato. Se si ha familiarità con le toolchain, è possibile impostare la propria toolchain.\n\nPer iniziare, fare clic su **Crea**."
-template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:**Ora è possibile aggiungere le integrazioni di strumenti.Per le istruzioni passo dopo passo, consultare [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) per questa toolchain."

--- a/.bluemix/nls/messages_ja.yml
+++ b/.bluemix/nls/messages_ja.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Build your own ツールチェーン"
 template.description: "このツールチェーンには、事前構成されたツールは含まれていません。ツールチェーンを既に熟知している場合、独自のツールチェーンをセットアップできます。\n\n開始するには、**「作成」**をクリックします。"
-template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** 現在、ツール統合を追加できます。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)を参照してください。"

--- a/.bluemix/nls/messages_ko.yml
+++ b/.bluemix/nls/messages_ko.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "사용자 자체 도구 체인 빌드"
 template.description: "이 도구 체인에는 사전 구성된 도구가 없습니다. 도구 체인에 이미 익숙한 경우 사용자 자체 도구 체인을 설정할 수 있습니다. \n\n계속하려면 **작성**을 클릭하십시오."
-template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** 이제 도구 통합을 추가할 수 있습니다. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)을 참조하십시오."

--- a/.bluemix/nls/messages_pt_BR.yml
+++ b/.bluemix/nls/messages_pt_BR.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "Construa sua própria cadeia de ferramentas"
 template.description: "Essa cadeia de ferramentas não possui ferramentas pré-configuradas. Se você já estiver familiarizado com as cadeias de ferramentas, será possível configurar sua própria cadeia de ferramentas.\n\nPara iniciar, clique em **Criar**."
-template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Você agora pode incluir integrações de ferramenta. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom) para esta cadeia de ferramentas."

--- a/.bluemix/nls/messages_zh.yml
+++ b/.bluemix/nls/messages_zh.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "构建您自己的工具链"
 template.description: "此工具链没有任何预配置的工具。如果您已经熟悉工具链，那么可以设置您自己的工具链。\n\n单击**创建**以开始。"
-template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 现在您可以添加工具集成。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/nls/messages_zh_HK.yml
+++ b/.bluemix/nls/messages_zh_HK.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "建置您專屬的工具鏈"
 template.description: "此工具鏈沒有預先配置的工具。如果您已經熟悉工具鏈，則可以設定自己的工具鏈。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 您現在可以新增工具整合。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/nls/messages_zh_TW.yml
+++ b/.bluemix/nls/messages_zh_TW.yml
@@ -1,4 +1,3 @@
 ---
 template.name: "建置您專屬的工具鏈"
 template.description: "此工具鏈沒有預先配置的工具。如果您已經熟悉工具鏈，則可以設定自己的工具鏈。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 您現在可以新增工具整合。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_custom)。"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -14,6 +14,6 @@ toolchain:
   name: 'empty-toolchain-{{timestamp}}'
   template:
     getting_started:
-      $ref: "#/messages/template.gettingStarted"
+      $ref: locales_getting_started.yml
 services: {}
 form: {}


### PR DESCRIPTION
Store all translations of 'getting started' message in the `toolchain.template` field.
This allows the UI to choose which string to display according to the browser locale.